### PR TITLE
Project requirements.txt

### DIFF
--- a/.python-version
+++ b/.python-version
@@ -1,0 +1,1 @@
+amooora

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+jupyter-contrib-core==0.4.0
+jupyter-contrib-nbextensions==0.5.1
+jupyter-highlight-selected-word==0.2.0
+jupyter-latex-envs==1.4.6
+jupyter-nbextensions-configurator==0.5.0
+jupyter-resource-usage==0.6.3
+jupyter-server==1.21.0
+jupyter_client==7.4.3
+jupyter_core==4.11.2
+jupyterlab==3.4.8
+jupyterlab-pygments==0.2.2
+jupyterlab-widgets==1.1.1
+jupyterlab_server==2.16.1
+autopep8==2.3.2


### PR DESCRIPTION
Quando fui utilizar o `jupyter notebook` percebi que ele estava com uma configuração totalmente diferente do que utilizamos no bootcamp. Para solucionar eu adicionei os pacotes necessários na minha máquina com a ajuda do Hiroshi. 

Como adicionei pacotes no environment, ele sugeriu que eu criasse o `requirements.txt` para que a gente fique com as mesmas versões dos pacotes. 